### PR TITLE
chore(api): require Node.js >=20.20.0 (LTS 20)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,7 @@
     "test:watch": "jest --watch"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.20.0"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",


### PR DESCRIPTION
## Objetivo del PR
- Requerir Node.js >=20.20.0 (LTS 20) en el API para alinear con Prisma 7 y otras dependencias que exigen Node 20+, y evitar fallos de build en Railway/CI.

## Tipo de cambio
- [x] chore (config/build)

## Referencia a documentación
- RF relacionados: N/A
- RNF relacionados: N/A
- RB relacionadas: N/A
- Edge cases impactados: N/A
- ADR (si aplica): N/A

## OpenAPI / API First
- [x] N/A — No cambia endpoints ni modelos.

## Seguridad por código
- [x] N/A — Solo cambio en package.json engines.

## Errores, logs y auditoría
- [x] N/A

## Offline / cache (si aplica)
- [x] N/A

## Pruebas
- [x] N/A — Config de build; validar que CI/Railway use Node 20+.

## Migraciones/DB (si aplica)
- [x] N/A

## No assets externos
- [x] No se usan ni añaden assets.

## Cómo probar (pasos exactos)
1) Tener Node 20.20+ (`node -v`).
2) `cd apps/api && npm ci && npm run build`.
3) En Railway/CI: asegurar Node 20+ (ej. NODE_VERSION o .nvmrc).

## Capturas / evidencia
- [ ] Opcional: output de `node -v` y `npm run build`.

## Trade-offs y riesgos
- **Trade-offs:** Quien use Node 18 debe actualizar a 20.20+.
- **Riesgos:** Bajo.
- **Mitigación:** README/CI con requisito Node >=20.20.0.
